### PR TITLE
feat(cb2-2097): add retrieval of secrets function and fix pipeline linting issues

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ node_modules
 .serverless
 .vscode
 *.config.js
+**/config/*.ts
 **/*.js
 .build,
 jest.config.ts

--- a/src/crm/dynamicsWebApi.ts
+++ b/src/crm/dynamicsWebApi.ts
@@ -30,8 +30,8 @@ function createDynamoTestStation(obj: DynamicsTestStation): DynamoTestStation {
     throw new Error(
       `Invalid enum value provided for test station type field: ${obj.dvsa_testfacilitytype} for test station: ${obj.accountid}`,
     );
-  } 
-  return { 
+  }
+  return {
     testStationId: obj.accountid,
     testStationAccessNotes: null,
     testStationAddress: `${obj.address1_line1}, ${obj.address1_line2}`,
@@ -46,7 +46,7 @@ function createDynamoTestStation(obj: DynamicsTestStation): DynamoTestStation {
     testStationStatus: TestStationStatus.get(obj.dvsa_accountstatus),
     testStationTown: obj.address1_city,
     testStationType: TestStationType.get(obj.dvsa_testfacilitytype),
-  }
+  };
 }
 
 const onRejected = (error: AxiosError) => {

--- a/src/crm/getToken.ts
+++ b/src/crm/getToken.ts
@@ -1,11 +1,14 @@
 import { ConfidentialClientApplication, AuthenticationResult } from '@azure/msal-node';
 import config from '../config';
+import { getSecret } from '../utils/getSecret';
 
 export async function getToken() {
+  const clientSecretValue = await getSecret(config.crm.ceClientSecret);
+
   const cca = new ConfidentialClientApplication({
     auth: {
       clientId: config.crm.ceClientId,
-      clientSecret: config.crm.ceClientSecret,
+      clientSecret: clientSecretValue,
       authority: config.crm.ceAuthority,
     },
   });

--- a/src/utils/getSecret.ts
+++ b/src/utils/getSecret.ts
@@ -1,0 +1,8 @@
+import { SecretsManager } from 'aws-sdk';
+
+async function getSecret(secretName: string): Promise<string> {
+  const secretsManager = new SecretsManager();
+  const secretValue = await secretsManager.getSecretValue({ SecretId: secretName }).promise();
+  return secretValue.SecretString;
+}
+export { getSecret };

--- a/tests/unit/getToken.test.ts
+++ b/tests/unit/getToken.test.ts
@@ -1,8 +1,14 @@
 import { ConfidentialClientApplication, AuthenticationResult } from '@azure/msal-node';
+import { mocked } from 'ts-jest/utils';
 import config from '../../src/config';
 import { getToken } from '../../src/crm/getToken';
+import { getSecret } from '../../src/utils/getSecret';
+
+jest.mock('../../src/utils/getSecret');
 
 describe('getToken', () => {
+  mocked(getSecret).mockResolvedValue('SECRET');
+
   const RESULT: AuthenticationResult = {
     authority: '',
     uniqueId: '',
@@ -34,6 +40,7 @@ describe('getToken', () => {
     config.crm.ceAuthority = 'https://login.microsoftonline.com/xyz';
 
     const ERROR = new Error('Hello');
+
     ConfidentialClientApplication.prototype.acquireTokenByClientCredential = jest.fn().mockRejectedValue(ERROR);
 
     return expect(getToken).rejects.toThrow('Hello');


### PR DESCRIPTION
## VTA to source ATF information from Dynamics
Add functionality to retrieve CE secret from AWS secrets manager for JWT token generation and fix some linting issues around config file
[link to ticket number](https://jira.dvsacloud.uk/browse/CB2-2097)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number