### PR TITLE
feat(cb2-2097): add test station list filtering and change email field to array

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,6 +7,7 @@ export default {
     ceAccountUrl: process.env.CE_ACCOUNT_URL || '',
     maxRetryAttempts: process.env.MAX_RETRY_ATTEMPTS || '',
     scalingDuration: process.env.MAX_SCALING_DURATION || '',
+    siteList: process.env.STATION_LIST_SECRET || ''
   },
   aws: {
     eventBusSource: process.env.AWS_EVENT_BUS_SOURCE || '',

--- a/src/crm/DynamoTestStation.ts
+++ b/src/crm/DynamoTestStation.ts
@@ -3,7 +3,7 @@ interface DynamoTestStation {
   testStationAccessNotes: string;
   testStationAddress: string;
   testStationContactNumber: string;
-  testStationEmails: string;
+  testStationEmails: string[];
   testStationGeneralNotes: string;
   testStationLongitude: string;
   testStationLatitude: string;

--- a/tests/unit/dynamicsWebApi.test.ts
+++ b/tests/unit/dynamicsWebApi.test.ts
@@ -1,15 +1,20 @@
 import axios from 'axios-observable';
 import { of } from 'rxjs';
+import { mocked } from 'ts-jest/utils';
 import { AxiosResponse, AxiosError } from 'axios';
 import { getTestStationEntities, onRejected, createDynamoTestStation } from '../../src/crm/dynamicsWebApi';
 import { DynamoTestStation } from '../../src/crm/DynamoTestStation';
 import { DynamicsTestStation } from '../../src/crm/DynamicsTestStation';
+import { getSecret } from '../../src/utils';
 
 jest.mock('../../src/crm/getToken', () => ({
   getToken: jest.fn().mockResolvedValueOnce({ value: 'MOCKED_BEARER_TOKEN' }),
 }));
+jest.mock('../../src/utils/index');
 
 describe('dynamicsWebApi', () => {
+  mocked(getSecret).mockResolvedValue('P601,P602');
+
   const MOCK_BAD_DATA: DynamicsTestStation = {
     '@odata.etag': 'string',
     accountid: '1234',
@@ -45,7 +50,7 @@ describe('dynamicsWebApi', () => {
           address1_longitude: 'string',
           address1_latitude: 'string',
           name: 'string',
-          dvsa_premisecodes: 'string',
+          dvsa_premisecodes: 'P601',
           address1_postalcode: 'string',
           dvsa_accountstatus: 147160001,
           address1_city: 'string',
@@ -64,7 +69,26 @@ describe('dynamicsWebApi', () => {
           address1_longitude: 'string',
           address1_latitude: 'string',
           name: 'string',
-          dvsa_premisecodes: 'string',
+          dvsa_premisecodes: 'P602',
+          address1_postalcode: 'string',
+          dvsa_accountstatus: 147160001,
+          address1_city: 'string',
+          dvsa_testfacilitytype: 147160000,
+          modifiedon: '',
+        },
+        {
+          '@odata.etag': 'string',
+          accountid: 'string',
+          address1_composite: 'string',
+          address1_line1: 'Address 1',
+          address1_line2: 'Address 2',
+          telephone1: 'string',
+          emailaddress1: 'string',
+          dvsa_openingtimes: 'string',
+          address1_longitude: 'string',
+          address1_latitude: 'string',
+          name: 'string',
+          dvsa_premisecodes: 'P6012',
           address1_postalcode: 'string',
           dvsa_accountstatus: 147160001,
           address1_city: 'string',
@@ -86,12 +110,12 @@ describe('dynamicsWebApi', () => {
       testStationAccessNotes: null,
       testStationAddress: 'Address 1, Address 2',
       testStationContactNumber: 'string',
-      testStationEmails: 'string',
+      testStationEmails: ['string'],
       testStationGeneralNotes: 'string',
       testStationLongitude: 'string',
       testStationLatitude: 'string',
       testStationName: 'string',
-      testStationPNumber: 'string',
+      testStationPNumber: 'P601',
       testStationPostcode: 'string',
       testStationStatus: 'Active',
       testStationTown: 'string',
@@ -102,12 +126,12 @@ describe('dynamicsWebApi', () => {
       testStationAccessNotes: null,
       testStationAddress: 'Address 1, Address 2',
       testStationContactNumber: 'string',
-      testStationEmails: 'string',
+      testStationEmails: ['string'],
       testStationGeneralNotes: null,
       testStationLongitude: 'string',
       testStationLatitude: 'string',
       testStationName: 'string',
-      testStationPNumber: 'string',
+      testStationPNumber: 'P602',
       testStationPostcode: 'string',
       testStationStatus: 'Active',
       testStationTown: 'string',
@@ -137,9 +161,10 @@ describe('dynamicsWebApi', () => {
     });
   });
 
-  test('GIVEN mock axios odata succesful response WHEN called THEN returns array of DynamoTestStation objects', async () => {
+  test('GIVEN mock axios odata succesful response WHEN called THEN returns array of filtered DynamoTestStation objects', async () => {
     axios.get = jest.fn().mockReturnValueOnce(of(MOCK_DATA));
     const result = await getTestStationEntities('');
+    expect(result.length).toBe(2)
     expect(result).toEqual(MOCK_RESULT);
   });
 

--- a/tests/unit/getTestStation.test.ts
+++ b/tests/unit/getTestStation.test.ts
@@ -1,13 +1,16 @@
 import axios from 'axios-observable';
 import { throwError, of } from 'rxjs';
+import { mocked } from 'ts-jest/utils';
 import { AxiosResponse } from '../../node_modules/axios-observable/node_modules/axios/index.d';
 import { getTestStations } from '../../src/crm/getTestStation';
 import * as GetTestStations from '../../src/crm/dynamicsWebApi';
 import config from '../../src/config';
+import { getSecret } from '../../src/utils';
 
 jest.mock('../../src/crm/getToken', () => ({
   getToken: jest.fn().mockResolvedValue({ value: 'MOCKED_BEARER_TOKEN' }),
 }));
+jest.mock('../../src/utils/index');
 
 const MOCK_DATA: AxiosResponse = {
   data: {
@@ -40,6 +43,8 @@ const MOCK_DATA: AxiosResponse = {
 };
 
 describe('retryStrategy', () => {
+  mocked(getSecret).mockResolvedValue('P601,P602');
+
   test('GIVEN an odata endpoint WHEN there is a short transient error and no retries THEN the call is not successful.', async () => {
     config.crm.maxRetryAttempts = '0';
     config.crm.scalingDuration = '100';


### PR DESCRIPTION

## Only send the updated sites to dynamo if they are in the allow list
Filters incoming odata response based on a list of test station P numbers stored in AWS Secrets Manager, so only changes that have been made to these test stations will be sent to DynamoDB. Also made the email field that is sent to DynamoDB an array
[link to ticket number](https://jira.dvsacloud.uk/browse/CB2-2468)

## Checklist
- [ ] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number