### PR TITLE
fix(cb2-2617): correct accounts odata call parameters

### DIFF
--- a/src/crm/getTestStation.ts
+++ b/src/crm/getTestStation.ts
@@ -11,7 +11,7 @@ export const getTestStations = async (date: Date): Promise<DynamoTestStation[]> 
 
   logger.info(`Trying to get test stations informations modified since: ${modifiedOnDate}`);
 
-  const filteredUrl = `${ceUrl}/accounts/?$select=accountid,address1_composite,name,emailaddress1,dvsa_premisecodes,dvsa_testfacilitytype,dvsa_accountstatus,address1_latitude,address1_longitude,telephone1,dvsa_openingtimes,modifiedon&$filter=modifiedon%20ge%20${modifiedOnDate}`;
+  const filteredUrl = `${ceUrl}/accounts/?$select=accountid,address1_line1,address1_line2,telephone1,dvsa_openingtimes,address1_longitude,address1_latitude,name,dvsa_premisecodes,address1_postalcode,dvsa_accountstatus,address1_city,dvsa_testfacilitytype,modifiedon&$filter=modifiedon%20ge%20${modifiedOnDate}`;
 
   const run = async (): Promise<DynamoTestStation[]> => {
     const response = await getTestStationEntities(filteredUrl);

--- a/tests/unit/getTestStation.test.ts
+++ b/tests/unit/getTestStation.test.ts
@@ -92,7 +92,7 @@ describe('getTestStation', () => {
     config.crm.ceBaseUrl = 'http://testapi';
     await getTestStations(new Date('2020-10-21'));
     expect(spy).toHaveBeenCalledWith(
-      'http://testapi/accounts/?$select=accountid,address1_composite,name,emailaddress1,dvsa_premisecodes,dvsa_testfacilitytype,dvsa_accountstatus,address1_latitude,address1_longitude,telephone1,dvsa_openingtimes,modifiedon&$filter=modifiedon%20ge%202020-10-21',
+      'http://testapi/accounts/?$select=accountid,address1_line1,address1_line2,telephone1,dvsa_openingtimes,address1_longitude,address1_latitude,name,dvsa_premisecodes,address1_postalcode,dvsa_accountstatus,address1_city,dvsa_testfacilitytype,modifiedon&$filter=modifiedon%20ge%202020-10-21',
     );
   });
 });


### PR DESCRIPTION
## Multiple email addresses for ATF
Fixes OData call to CRM accounts table, previously wasn't requesting address1_line1, address1_line2, address1_postalcode or address1_city fields from CE
[link to ticket number](https://jira.dvsacloud.uk/browse/CB2-2617)

## Checklist
- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [X] Squashed commit contains the JIRA ticket number